### PR TITLE
Fix some errors

### DIFF
--- a/cj3.txt
+++ b/cj3.txt
@@ -34614,7 +34614,6 @@ awli   𣉳
 awlu   𣋍
 awly   𣋖
 awma   𣰱
-bwmf   𣎈
 awmv   𣉍
 ay     𣅂
 ay     𣅃
@@ -37042,6 +37041,7 @@ bwlg   𦣇
 bwli   𡬳
 bwli   𦞗
 bwll   𤔴
+bwmf   𣎈
 bwmg   𦛢
 bwml   𦜠
 bwmo   𦞢
@@ -42281,7 +42281,6 @@ fomb   𤓀
 fomb   𤍼
 fombc  𩕈
 fomm   𤈷
-gomo   𡑯
 fonui  𧼧
 fooa   𤎳
 foog   𤉛
@@ -43611,6 +43610,7 @@ gommj  𧻀
 gommn  𧺗
 gomn   𡉛
 gomni  𧺰
+gomo   𡑯
 gomoc  𧾒
 gomrt  𧻿
 gomso  𧼙
@@ -45147,7 +45147,6 @@ hduu   𦤙
 hduui  𥣼
 hduvi  𥠃
 hdveu  𨤖
-hfvis  𪀂
 hdvle  𨤑
 hdvot  𧰌
 hdvou  𨤖
@@ -45541,6 +45540,7 @@ hfurj  𪇷
 hfvif  𦂎
 hfvii  𪅹
 hfvik  𪅹
+hfvis  𪀂
 hfvjr  𪂯
 hfwim  𪅦
 hfwl   𩿼
@@ -62615,6 +62615,7 @@ odhaf  𩿽
 odhaf  𪀪
 odhaf  𪃁
 odhaf  𪆐
+odhj   𠉟
 odhvo  𤫿
 odi    𢧅
 odif   𩿧
@@ -64934,7 +64935,6 @@ pddn   𢟼
 pdhaf  𪀶
 pdhaf  𪃸
 pdhi   𩳶
-odhj   𠉟
 pdhqu  𣮕
 pdj    𢗿
 pdje   𢘦
@@ -84265,6 +84265,7 @@ mrhn   𫇔
 mrhqj  𪿪
 mrhyj  𪿺
 mrhyt  𪿱
+mridd  𪿳
 mrijc  𪿳
 mrir   𪿘
 mrjau  𪿷
@@ -84322,7 +84323,6 @@ msomo  𪜇
 mtco   𪠖
 mthhq  𪫊
 mthhu  𫌟
-mridd  𪿳
 mtitf  𪪩
 mtjmn  𫎄
 mtlc   𪠓
@@ -84487,7 +84487,6 @@ nkpym  𫛼
 nktcw  𪪰
 nkw    𪪮
 nkwyl  𪜖
-nlyk   𫔻
 nlamn  𫔿
 nlapv  𫕈
 nlatc  𫠃
@@ -84519,6 +84518,7 @@ nlsj   𫔾
 nltk   𫕀
 nltmb  𫕕
 nlycb  𫕒
+nlyk   𫔻
 nlykl  𫕅
 nlysf  𫕗
 nmajv  𫘫
@@ -87109,6 +87109,7 @@ dm     𬂜
 dmdm   𬂡
 dmgs   𬂿
 dmku   𬂠
+dmlm   𬂲
 dmmc   𬄝
 dmmo   𬃛
 dmmp   𬄚
@@ -87312,7 +87313,6 @@ emhf   𬈛
 emhqu  𬇇
 emil   𬈖
 eml    𬇧
-dmlm   𬂲
 emob   𬇞
 ems    𬇕
 emsm   𬇸
@@ -93675,7 +93675,6 @@ dipw   𭭀
 dive   𭩰
 diyrb  𮪺
 djjd   𭬕
-pjkd   𭜸
 djnp   𭪮
 djqi   𮌁
 djtd   𭪷
@@ -93813,10 +93812,12 @@ dvo    𭩟
 dvoi   𭬧
 dwnl   𮟽
 dwomd  𭫧
+dycb   𭫶
 dycr   𭬍
 dydi   𭪆
 dyhl   𭪧
 dyhr   𭫙
+dyid   𭪱
 dymr   𭪐
 dymt   𭬜
 dymy   𭩦
@@ -94125,13 +94126,11 @@ ewrhp  𭊼
 ews    𭰊
 ewwk   𭳸
 eybk   𭲋
-dycb   𭫶
 eyce   𭱝
 eycj   𭰺
 eygg   𭲗
 eyhp   𭳩
 eyhs   𭱕
-dyid   𭪱
 eykf   𭲍
 eykl   𭲍
 eykm   𭲴
@@ -94827,6 +94826,7 @@ hetm   𭺰
 hey    𭐝
 heymr  𮗺
 hfbnd  𮬻
+hfhn   𮬥
 hfhon  𮬷
 hfhsk  𮭂
 hfihr  𮭄
@@ -94836,6 +94836,7 @@ hflbu  𮬮
 hfln   𭄔
 hfmnp  𮬳
 hfmsk  𮭂
+hfmu   𮬦
 hfpfd  𮭀
 hfpsl  𭅿
 hfpya  𮧿
@@ -94868,8 +94869,6 @@ hhfsm  𮜴
 hhhb   𭛖
 hhjwj  𮝉
 hhkm   𮜰
-jjkni  𮜿
-jjknk  𮜿
 hhks   𭄠
 hhks   𭄨
 hhlwp  𮜸
@@ -95884,6 +95883,8 @@ jjkcs  𭅪
 jjkjt  𮝔
 jjkmm  𮋙
 jjkms  𮝎
+jjkni  𮜿
+jjknk  𮜿
 jjkp   𭓮
 jjlib  𮝢
 jjmdm  𮝬
@@ -96310,7 +96311,6 @@ lcq    𭢅
 lcymr  𮘤
 ldam   𮖕
 ldbm   𮖕
-lidbn  𮔗
 le     𮕧
 led    𭬢
 lew    𭻭
@@ -96336,6 +96336,7 @@ libbm  𮔎
 licc   𮓼
 licii  𮕒
 licwa  𮔿
+lidbn  𮔗
 lihbt  𮔆
 lihoi  𮔹
 lihop  𮕏
@@ -97397,6 +97398,7 @@ nfkhw  𮬎
 nfkki  𮫶
 nfkni  𮫰
 nfknk  𮫰
+nfleg  𮫹
 nfllp  𮬌
 nfmbe  𮬙
 nfmht  𮬗
@@ -97454,7 +97456,6 @@ nkhqm  𭚕
 nkhv   𭚓
 nkji   𭐳
 nkks   𭄶
-nfleg  𮫹
 nkleg  𮫹
 nkmhq  𭷳
 nkmui  𭚒
@@ -98159,6 +98160,7 @@ pjcg   𭟃
 pjcn   𭝄
 pjhaf  𮬰
 pjif   𭟫
+pjkd   𭜸
 pka    𭥘
 pkaf   𭝷
 pkbl   𭝣
@@ -99104,7 +99106,6 @@ sfeee  𮩾
 sff    𭵢
 sfff   𮪋
 sfhds  𮪆
-hfhn   𮬥
 sfije  𮪅
 sfjcv  𮪠
 sfjnd  𮪃
@@ -99121,7 +99122,6 @@ sfmlu  𮩷
 sfmmi  𮪝
 sfmob  𮩺
 sfmtp  𮪜
-hfmu   𮬦
 sfmvu  𮩷
 sfmwd  𮪕
 sfnau  𮪀
@@ -99588,7 +99588,6 @@ tkha   𮐫
 tkhb   𮐑
 tkhg   𮐴
 tkhi   𮏺
-ukhk   𭗢
 tkhk   𮏶
 tkhr   𮏛
 tkhu   𮏜
@@ -99940,6 +99939,7 @@ ujjj   𭗠
 ujpu   𭗈
 ujpu   𭗏
 ujru   𭖡
+ukhk   𭗢
 ukk    𭑄
 uklg   𭖘
 ukmcp  𭂿

--- a/cj3.txt
+++ b/cj3.txt
@@ -34614,7 +34614,7 @@ awli   𣉳
 awlu   𣋍
 awly   𣋖
 awma   𣰱
-awmf   𣎈
+bwmf   𣎈
 awmv   𣉍
 ay     𣅂
 ay     𣅃
@@ -42281,7 +42281,7 @@ fomb   𤓀
 fomb   𤍼
 fombc  𩕈
 fomm   𤈷
-fomo   𡑯
+gomo   𡑯
 fonui  𧼧
 fooa   𤎳
 foog   𤉛
@@ -45147,7 +45147,7 @@ hduu   𦤙
 hduui  𥣼
 hduvi  𥠃
 hdveu  𨤖
-hdvis  𪀂
+hfvis  𪀂
 hdvle  𨤑
 hdvot  𧰌
 hdvou  𨤖
@@ -64934,7 +64934,7 @@ pddn   𢟼
 pdhaf  𪀶
 pdhaf  𪃸
 pdhi   𩳶
-pdhj   𠉟
+odhj   𠉟
 pdhqu  𣮕
 pdj    𢗿
 pdje   𢘦
@@ -84322,7 +84322,7 @@ msomo  𪜇
 mtco   𪠖
 mthhq  𪫊
 mthhu  𫌟
-mtidd  𪿳
+mridd  𪿳
 mtitf  𪪩
 mtjmn  𫎄
 mtlc   𪠓
@@ -84487,7 +84487,7 @@ nkpym  𫛼
 nktcw  𪪰
 nkw    𪪮
 nkwyl  𪜖
-nkyk   𫔻
+nlyk   𫔻
 nlamn  𫔿
 nlapv  𫕈
 nlatc  𫠃
@@ -87312,7 +87312,7 @@ emhf   𬈛
 emhqu  𬇇
 emil   𬈖
 eml    𬇧
-emlm   𬂲
+dmlm   𬂲
 emob   𬇞
 ems    𬇕
 emsm   𬇸
@@ -93675,7 +93675,7 @@ dipw   𭭀
 dive   𭩰
 diyrb  𮪺
 djjd   𭬕
-djkd   𭜸
+pjkd   𭜸
 djnp   𭪮
 djqi   𮌁
 djtd   𭪷
@@ -94125,13 +94125,13 @@ ewrhp  𭊼
 ews    𭰊
 ewwk   𭳸
 eybk   𭲋
-eycb   𭫶
+dycb   𭫶
 eyce   𭱝
 eycj   𭰺
 eygg   𭲗
 eyhp   𭳩
 eyhs   𭱕
-eyid   𭪱
+dyid   𭪱
 eykf   𭲍
 eykl   𭲍
 eykm   𭲴
@@ -94868,8 +94868,8 @@ hhfsm  𮜴
 hhhb   𭛖
 hhjwj  𮝉
 hhkm   𮜰
-hhkni  𮜿
-hhknk  𮜿
+jjkni  𮜿
+jjknk  𮜿
 hhks   𭄠
 hhks   𭄨
 hhlwp  𮜸
@@ -96310,7 +96310,7 @@ lcq    𭢅
 lcymr  𮘤
 ldam   𮖕
 ldbm   𮖕
-ldbn   𮔗
+lidbn  𮔗
 le     𮕧
 led    𭬢
 lew    𭻭
@@ -97454,6 +97454,7 @@ nkhqm  𭚕
 nkhv   𭚓
 nkji   𭐳
 nkks   𭄶
+nfleg  𮫹
 nkleg  𮫹
 nkmhq  𭷳
 nkmui  𭚒
@@ -99103,7 +99104,7 @@ sfeee  𮩾
 sff    𭵢
 sfff   𮪋
 sfhds  𮪆
-sfhn   𮬥
+hfhn   𮬥
 sfije  𮪅
 sfjcv  𮪠
 sfjnd  𮪃
@@ -99120,7 +99121,7 @@ sfmlu  𮩷
 sfmmi  𮪝
 sfmob  𮩺
 sfmtp  𮪜
-sfmu   𮬦
+hfmu   𮬦
 sfmvu  𮩷
 sfmwd  𮪕
 sfnau  𮪀
@@ -99587,7 +99588,7 @@ tkha   𮐫
 tkhb   𮐑
 tkhg   𮐴
 tkhi   𮏺
-tkhk   𭗢
+ukhk   𭗢
 tkhk   𮏶
 tkhr   𮏛
 tkhu   𮏜

--- a/cj3.txt
+++ b/cj3.txt
@@ -1849,7 +1849,6 @@ cmrr   鎶
 cmrt   鋀
 cmrw   鍢
 cms    鈩
-cmso   㒸
 cmsu   鈪
 cmt    鈃
 cmtn   鉶
@@ -26128,7 +26127,6 @@ amca   㬐
 amdi   㝵
 amgc   㬄
 amia   㬐
-amll   𣌮
 amne   㫤
 amrb   㬏
 amtc   㫫
@@ -26744,6 +26742,7 @@ cmdm   䥶
 cmjh   䤯
 cmkh   䤯
 cmrl   䤺
+cmso   㒸
 cmst   㿽
 cmta   䥄
 cmth   䤯
@@ -29665,6 +29664,7 @@ lmky   䙣
 lmrb   䙐
 lmto   䙠
 lmwv   䙅
+lmyyc  䫍
 lnhjd  㸡
 lnhqu  㲏
 lnkm   䘰
@@ -29750,7 +29750,6 @@ lyhq   㹃
 lyhuu  䩁
 lyib   䘻
 lyiu   䘪
-lmyyc  䫍
 lymgi  㻗
 lymp   䘣
 lyn    㐟
@@ -33412,8 +33411,8 @@ yrbbe  䛵
 yrbfn  䊨
 yrbg   㙜
 yrbk   䯨
-yrbu   䯩
 yrbmm  䛁
+yrbu   䯩
 yrbyk  䇔
 yrbyn  䇔
 yrcms  䚷
@@ -33992,9 +33991,9 @@ ambi   𣊯
 ambl   𣆝
 ambm   𣌟
 ambm   𣇥
+ambu   𣋔
 ambuu  𧡰
 ambuu  𧡶
-ambu   𣋔
 ambv   𣋔
 amca   𣋗
 amdm   𣌅
@@ -34015,6 +34014,7 @@ amjv   𡝎
 amk    𣅐
 amks   𠡎
 amlk   𣆳
+amll   𣌮
 amll   𣇅
 amln   𠛣
 amln   𠞈
@@ -36528,8 +36528,8 @@ buipp  𥋨
 buirm  𥇿
 buis   𥄅
 buist  𥊱
-buiti  𧡉
 buitf  𧡉
+buiti  𧡉
 buiuh  𥆙
 buiwg  𥌬
 buixp  𥉶
@@ -36625,9 +36625,9 @@ bumbr  𥌼
 bumbw  𥋸
 bumcw  𥆺
 bumdm  𥄬
+bumdm  𥌮
 bume   𥈍
 bumem  𥈂
-bumdm  𥌮
 bumf   𥄚
 bumfb  𥌃
 bumfm  𥅊
@@ -41610,6 +41610,7 @@ fdmbg  𥽥
 fdmbi  𥼸
 fdmbk  𥻟
 fdmbl  𥼸
+fdmbl  𡭺
 fdmbm  𥽛
 fdmbm  𥾂
 fdmbn  𥽮
@@ -41935,8 +41936,8 @@ fghaf  𪅓
 fghi   𤐡
 fgi    𢧵
 fgi    𤆧
-fgihf  𪇲
 fgih   𡮊
+fgihf  𪇲
 fgii   𡮊
 fgji   𤎒
 fgjk   𤎒
@@ -41985,7 +41986,6 @@ fhlmi  𧏟
 fhln   𠚺
 fhlq   𤏫
 fhmbc  𩔫
-fdmbl  𡭺
 fhmy   𤇚
 fhni   𤆘
 fhni   𩖟
@@ -43499,6 +43499,7 @@ gohgr  𧻰
 gohhd  𧾅
 gohhj  𧼠
 gohhw  𧽖
+gohi   𡌠
 gohii  𧾶
 gohj   𧺛
 gohjg  𧼩
@@ -43507,7 +43508,6 @@ gohjx  𧼰
 gohkm  𧾓
 gohky  𧾁
 gohli  𧻽
-gohi   𡌠
 gohm   𡌠
 gohn   𧺋
 gohne  𣪳
@@ -44181,7 +44181,6 @@ hahej  𩡇
 haher  𤽥
 hahhj  𤽹
 hahhj  𤾁
-hghi   𩲸
 hahkp  𩡋
 hahlo  𤽄
 hahlu  𤽇
@@ -45586,6 +45585,7 @@ hghaf  𪃫
 hghaj  𤾲
 hghd   𥠭
 hghdv  𡣢
+hghi   𩲸
 hghjg  𨤶
 hghne  𣪷
 hgi    𥬔
@@ -46643,8 +46643,8 @@ hmsmb  𨓼
 hmsqf  𩢫
 hmsqf  𩣷
 hmsu   𢀽
-hmsug  𣱒
 hmsu   𠨗
+hmsug  𣱒
 hmtbo  𤯻
 hmtms  𤯺
 hmtt   𡐱
@@ -47337,12 +47337,12 @@ honjk  𢕭
 honkn  𧗽
 honkn  𧗾
 honmf  𨓶
-honue  𢔈
 hono   𢓑
 hono   𢓙
 hono   𣢚
 honri  𢖞
 honsn  𧗻
+honue  𢔈
 hoo    𥬈
 hoo    𠂢
 hoob   𢓇
@@ -61057,8 +61057,8 @@ nftwd  𩻧
 nftwv  𩼅
 nftyb  𩹩
 nftyj  𩺵
-nftyv  𩷶
 nftyu  𩺊
+nftyv  𩷶
 nftyv  𩺊
 nfuce  𩼕
 nfuf   𩶚
@@ -61549,9 +61549,9 @@ nlhlb  𨺲
 nlhli  𨹤
 nlhml  𨸢
 nlhmo  𨼹
+nlhn   𨸔
 nlhnd  𨹄
 nlhne  𨸜
-nlhn   𨸔
 nlhni  𨺢
 nlhoc  𨽠
 nlhog  𨼦
@@ -72174,10 +72174,10 @@ teln   𠟝
 tels   𦶊
 tely   𦸪
 temd   𦽼
+temf   𧁛
 temg   𦹹
 temi   𦯫
 temi   𦴵
-temf   𧁛
 temk   𦺾
 temm   𧄻
 temn   𦭑
@@ -82254,8 +82254,8 @@ dlpc   𪴗
 dlpd   𪳧
 dlwp   𪳡
 dm     𫝀
-dmbd   𪴖
 dmbb   𪲔
+dmbd   𪴖
 dmbs   𪴟
 dmbu   𪴜
 dmda   𫞒
@@ -84265,7 +84265,6 @@ mrhn   𫇔
 mrhqj  𪿪
 mrhyj  𪿺
 mrhyt  𪿱
-mtidd  𪿳
 mrijc  𪿳
 mrir   𪿘
 mrjau  𪿷
@@ -84321,8 +84320,9 @@ msmv   𪠍
 msnl   𫟫
 msomo  𪜇
 mtco   𪠖
-mthhu  𫌟
 mthhq  𪫊
+mthhu  𫌟
+mtidd  𪿳
 mtitf  𪪩
 mtjmn  𫎄
 mtlc   𪠓
@@ -85870,8 +85870,8 @@ urob   𪨹
 ushd   𪩀
 usmt   𪩒
 usnd   𪩖
-utgi   𪩙
 utge   𪩝
+utgi   𪩙
 utmj   𪩓
 utw    𪨰
 uubdu  𪞺

--- a/contrib/sort-txt.mjs
+++ b/contrib/sort-txt.mjs
@@ -1,0 +1,78 @@
+import fs from "fs";
+import path from "path";
+
+if (process.argv.length <= 2) {
+  console.log(`Usage: node ./sort-txt.mjs path/to/cj3.txt`);
+}
+
+function block(ch) {
+  const cp = ch.codePointAt(0);
+  if (cp <= 0x4dbf && cp >= 0x3400) {
+    return 1; // Ext. A
+  } else if (cp <= 0xffff) {
+    return 0; // Basic + Misc
+  } else if (cp <= 0x2a6df) {
+    return 2;
+  } else if (cp <= 0x2b73f) {
+    return 3;
+  } else if (cp <= 0x2b81f) {
+    return 3; // Ext. C & Ext. D are mixed :(
+  } else if (cp <= 0x2ceaf) {
+    return 5;
+  } else if (cp <= 0x2ebef) {
+    return 6;
+  } else if (cp <= 0x3134f) {
+    return 7;
+  } else {
+    throw new Error(`Unsupported character: U+${cp.toString(16)} ${ch}`);
+  }
+}
+function sign(x, y) {
+  if (x < y) {
+    return -1;
+  }
+  if (x > y) {
+    return 1;
+  }
+  return 0;
+}
+
+function compare(cj1, cj2, ch1, ch2) {
+  const c = sign(block(ch1), block(ch2));
+  if (c !== 0) {
+    // sort by different blocks
+    return c;
+  } else {
+    if (block(ch1) === 0 && block(ch2) === 0) {
+      return 0; // do not sort BMP, which is manually sorted.
+    }
+    return sign(cj1, cj2);
+  }
+}
+
+function sortTxt(text) {
+  const [prefaces, items] = text.split("[DATA]\r\n");
+  const lines = items.split("\r\n");
+  lines.sort((l1, l2) => {
+    if (!l1 || !l2) {
+      return 0;
+    }
+    const CJMatchers = /^(?<cjcode>[a-z]+)\s+(?<character>.)/u;
+    try {
+      const { cjcode: cj1, character: ch1 } = CJMatchers.exec(l1).groups;
+      const { cjcode: cj2, character: ch2 } = CJMatchers.exec(l2).groups;
+      return compare(cj1, cj2, ch1, ch2);
+    } catch (e) {
+      console.error(e);
+      console.log(l1, l2);
+    }
+  });
+  return prefaces + "[DATA]\r\n" + lines.join("\r\n");
+}
+
+const txtPath = path.resolve(process.argv[2]);
+
+fs.writeFileSync(
+  txtPath,
+  sortTxt(fs.readFileSync(txtPath, { encoding: "utf-8" }))
+);


### PR DESCRIPTION
Fixes #27 

This PR should be reviewed commit by commit.

The first commit introduce a `sort-txt` utility, which basically enforce a keymaps order within `cj3.txt`. The order is never documented so it is just my speculation. I am happy to revise it if you think the order is incorrect. This script requires Node.js 14. I think it generally reduces maintenance cost when a keymap error is fixed.

The second commit reorders `cj3.txt` and fixes any inconsistencies here.

The third commit applies changes suggested by #27. Please review this commit carefully.

The fourth commit reorders `cj3.txt`, no surprise here.